### PR TITLE
bugfix_makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,14 @@ SHELL = /bin/bash
 
 CURRENT_DIR := $(shell pwd)
 INSTALL_DIR := $(CURRENT_DIR)/.venv
+PYTHON_LOCAL_DIR := $(CURRENT_DIR)/build/local
 PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
 
 #FIXME: put this variable in config file
-PYTHON_VERSION=3.7.4
-CURRENT_PYTHON_VERSION := $(shell python3 -c "import sys;t='{v[0]}.{v[1]}.{v[2]}'.format(v=list(sys.version_info[:]));sys.stdout.write(t)")
-PYTHON_VERSION_OK := $(shell python3 -c "import sys; t=sys.version_info[0:3]; print(int('{}.{}.{}'.format(*t) == '$(PYTHON_VERSION)'))")
+PYTHON_VERSION := 3.7.4
+SYSTEM_PYTHON_CMD := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
 
 # Commands
-SYSTEM_PYTHON_CMD := $(shell which python3)
 PYTHON_CMD := $(INSTALL_DIR)/bin/python3
 PIP_CMD := $(INSTALL_DIR)/bin/pip3
 FLASK_CMD := $(INSTALL_DIR)/bin/flask
@@ -21,20 +20,18 @@ all: help
 
 # This bit check define the build/python "target": if the system has an acceptable version of python, there will be no need to install python locally.
 
-ifeq ($(PYTHON_VERSION_OK),1)
-PYTHON_BINDIR := $(shell dirname $(PYTHON_CMD))
-PYTHONHOME := $(shell eval "cd $(PYTHON_BINDIR); pwd; cd > /dev/null")
+ifneq ($(SYSTEM_PYTHON_CMD),)
 build/python:
-		@echo $(CURRENT_PYTHON_VERSION)
-		@echo $(shell $(PYTHON_CMD) -c "print('OK')")
-		mkdir -p build
-		touch build/python;
-else
-build/python: local/bin/python3.7
+	@echo "Using system" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
+	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
 	mkdir -p build
-	touch build/python;
+	touch build/python
+else
+build/python: $(PYTHON_LOCAL_DIR)/bin/python3.7
+	@echo "Using local" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
+	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
 
-SYSTEM_PYTHON_CMD := $(CURRENT_DIR)/local/bin/python3.7
+SYSTEM_PYTHON_CMD := $(PYTHON_LOCAL_DIR)/bin/python3.7
 endif
 
 
@@ -60,16 +57,17 @@ help:
 # Build targets. Calling setup is all that is needed for the local files to be installed as needed. Bundesnetz may cause problem.
 
 python: build/python
-	@echo "Python installed"
+	@echo $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1) "installed"
 
 .PHONY: setup
 setup: python .venv/build.timestamp
 
 
-local/bin/python3.7:
-	mkdir -p $(CURRENT_DIR)/local;
-	curl -z $(CURRENT_DIR)/local/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(CURRENT_DIR)/local/Python-$(PYTHON_VERSION).tar.xz;
-	cd $(CURRENT_DIR)/local && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(CURRENT_DIR)/local/ && make altinstall
+$(PYTHON_LOCAL_DIR)/bin/python3.7:
+	@echo "Building a local python..."
+	mkdir -p $(PYTHON_LOCAL_DIR);
+	curl -z $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz;
+	cd $(PYTHON_LOCAL_DIR) && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(PYTHON_LOCAL_DIR)/ && make altinstall
 
 .venv/build.timestamp: build/python
 	$(SYSTEM_PYTHON_CMD) -m venv $(INSTALL_DIR) && $(PIP_CMD) install --upgrade pip setuptools
@@ -81,17 +79,16 @@ local/bin/python3.7:
 
 .PHONY: lint
 lint: .venv/build.timestamp
-		$(YAPF_CMD) -i --style .style.yapf $(PYTHON_FILES)
+	$(YAPF_CMD) -i --style .style.yapf $(PYTHON_FILES)
 
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.
 .PHONY: serve
 serve: .venv/build.timestamp
-		FLASK_APP=service_launcher FLASK_DEBUG=1 ${FLASK_CMD} run --host=0.0.0.0 --port=${HTTP_PORT}
+	FLASK_APP=service_launcher FLASK_DEBUG=1 ${FLASK_CMD} run --host=0.0.0.0 --port=${HTTP_PORT}
 
 .PHONY: gunicornserve
 gunicornserve: .venv/build.timestamp
-		${SYSTEM_PYTHON_CMD} wsgi.py
-
+	${SYSTEM_PYTHON_CMD} wsgi.py
 
 # Docker related functions.
 
@@ -108,7 +105,7 @@ shutdown:
 
 .PHONY: clean
 clean: clean_venv
-	rm -rf local;
+	rm -rf build;
 
 .PHONY: clean_venv
 clean_venv:

--- a/getPythonCmd.sh
+++ b/getPythonCmd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Search for a compatible python version on the system or in the local path
+# and return the path to it if found, otherwise returns nothing
+
+set -euo pipefail
+
+PYTHON_VERSION=${1-}
+PYTHON_LOCAL_DIR=${2-}
+PYTHON_MAJOR_VERSION=${PYTHON_VERSION%.*}
+
+if [ -z "${PYTHON_VERSION}" ]; then
+    >&2 echo "First parameter missing"
+    exit 1
+fi
+
+# shellcheck disable=SC2086
+for TMP_PYTHON_CMD in $(find ${PATH//:/ } ${PYTHON_LOCAL_DIR} -maxdepth 1 -executable -regextype sed -regex ".*/python3\.[0-9]*" 2> /dev/null | sort -V) ; do
+    VERSION=$(${TMP_PYTHON_CMD} --version 2>&1 | awk  '{print $2}')
+    if (( $(echo "${VERSION%.*} >= ${PYTHON_MAJOR_VERSION}" | bc -l) )); then
+        # echo "Found compatible python version: ${VERSION}"
+        SYSTEM_PYTHON_CMD=${TMP_PYTHON_CMD}
+        break
+    fi
+done
+
+echo "${SYSTEM_PYTHON_CMD-}"
+
+

--- a/getPythonCmd.sh
+++ b/getPythonCmd.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
-# Search for a compatible python version on the system or in the local path
-# and return the path to it if found, otherwise returns nothing
+# Search for a compatible python version on the system or in the local path and return the path to
+# it if found, otherwise returns nothing. The major version (e.g. python 3.x.x) must match.
+# The minor and micro version must be compatible (e.g. actual must be newer or equal than the
+# required)
 
 set -euo pipefail
 
 PYTHON_VERSION=${1-}
 PYTHON_LOCAL_DIR=${2-}
-PYTHON_MAJOR_VERSION=${PYTHON_VERSION%.*}
+PYTHON_MAJ_VERSION=${PYTHON_VERSION%%.*}        # strip minor and micro version
+PYTHON_MIN_MICR_VERSION=${PYTHON_VERSION#*.}    # strip major version
+
+compareVersionLte() {
+    # returns 1 if the version $1 is less or equal than version $1
+    [  "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
+}
 
 if [ -z "${PYTHON_VERSION}" ]; then
     >&2 echo "First parameter missing"
@@ -15,10 +23,17 @@ if [ -z "${PYTHON_VERSION}" ]; then
 fi
 
 # shellcheck disable=SC2086
-for TMP_PYTHON_CMD in $(find ${PATH//:/ } ${PYTHON_LOCAL_DIR} -maxdepth 1 -executable -regextype sed -regex ".*/python3\.[0-9]*" 2> /dev/null | sort -V) ; do
+for TMP_PYTHON_CMD in $(find ${PATH//:/ } ${PYTHON_LOCAL_DIR} -maxdepth 1 -executable \
+    -regextype sed -regex ".*/python3\.[0-9]*" 2> /dev/null | sort -V) ; do
     VERSION=$(${TMP_PYTHON_CMD} --version 2>&1 | awk  '{print $2}')
-    if (( $(echo "${VERSION%.*} >= ${PYTHON_MAJOR_VERSION}" | bc -l) )); then
-        # echo "Found compatible python version: ${VERSION}"
+    # Check that the major version match
+    if [ "${VERSION%%.*}" -ne "${PYTHON_MAJ_VERSION}" ]; then
+        # Major version don't match, skip it
+        continue
+    #elif (( $(echo "${VERSION#*.} >= ${PYTHON_MIN_MICR_VERSION}" | bc -l) )); then
+    elif compareVersionLte "${PYTHON_MIN_MICR_VERSION}" "${VERSION#*.}"; then
+        # Major version match and the minor.micro is also compatible sets
+        # the system python command.
         SYSTEM_PYTHON_CMD=${TMP_PYTHON_CMD}
         break
     fi


### PR DESCRIPTION

Now the python version check uses an exact match for the major version
and a compatible match for the minor.micro versions (e.g. actual >=
required). Also improved documentation of script.