### PR TITLE
Fixed Flask and Gunicorn application and added test target

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -14,9 +14,9 @@ class ReverseProxied(object):
 
     def __call__(self, environ, start_response):
         """
-        This function modifies the environment received by the WSGI, mostly making sure we serve the
-        right routes and that the application answers as if it were the initial host (for example,
-        an error should say that the site at reverse-proxied.admin.ch/generic_name/generate
+        This function modifies the environment received by the WSGI, mostly making sure we serve
+        the right routes and that the application answers as if it were the initial host (for
+        example, an error should say that the site at reverse-proxied.admin.ch/generic_name/generate
         encountered a problem, not that it was at internal.server/generate
 
         :param environ: the WSGI environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+gevent==20.6.2
 gunicorn==19.9.0
 flask==1.1.1

--- a/wsgi.py
+++ b/wsgi.py
@@ -24,7 +24,7 @@ class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
 
 # We use the port 8080 as default, otherwise we set the HTTP_PORT env variable within the container.
 if __name__ == '__main__':
-    HTTP_PORT = str(os.environ.get('HTTP_PORT'), "8080")
+    HTTP_PORT = str(os.environ.get('HTTP_PORT', "8080"))
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),


### PR DESCRIPTION
The application could not be started neither from Flask or from
Gunicorn.

 - gevent was missing from requirements and is required for the gunicorn
   worker
 - middleware renaming from ReverseProxied to ReverseProxies was not done
   every where
 - Default port for Flask was missing in MakeFile
 - The system python command was used instead of the virtualenv python
   commmand for starting gunicorn
 - wsgi.py had a typo for the HTTP port definition
 - Updated the MakeFile help

Also added the test target in makefile