### PR TITLE
BGDIINF_SB-1288: Push only docker image from master and develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ wheels/
 *.egg
 local/
 
+# makefile
+.local
+.timestamps
+
 # virtualenv
 .venv
 
@@ -49,5 +53,8 @@ nose2-junit.xml
 #vim
 *.swp
 
-# VS editor
-.vscode/
+# git generate files
+*.orig
+
+# visual studio code config
+.vscode

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+known_third_party=pytest
+known_flask=flask
+force_single_line=True
+sections=FUTURE,STDLIB,THIRDPARTY,FLASK,FIRSTPARTY,LOCALFOLDER

--- a/.pylintrc
+++ b/.pylintrc
@@ -360,7 +360,7 @@ spelling-store-unknown-words=no
 
 # The type of string formatting that logging methods do. `old` means using %
 # formatting, `new` is for `{}` formatting.
-logging-format-style=new
+logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.

--- a/Makefile
+++ b/Makefile
@@ -2,45 +2,48 @@ SHELL = /bin/bash
 
 .DEFAULT_GOAL := help
 
+SERVICE_NAME := service-color
+
 CURRENT_DIR := $(shell pwd)
-INSTALL_DIR := $(CURRENT_DIR)/.venv
-PYTHON_LOCAL_DIR := $(CURRENT_DIR)/build/local
-PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
+VENV := $(CURRENT_DIR)/.venv
+REQUIREMENTS = $(CURRENT_DIR)/requirements.txt
+DEV_REQUIREMENTS = $(CURRENT_DIR)/dev_requirements.txt
 TEST_REPORT_DIR := $(CURRENT_DIR)/tests/report
 TEST_REPORT_FILE := nose2-junit.xml
 
-#FIXME: put this variable in config file
+# Python local build directory
+PYTHON_LOCAL_DIR := $(CURRENT_DIR)/.local
+
+# venv targets timestamps
+VENV_TIMESTAMP = $(VENV)/.timestamp
+REQUIREMENTS_TIMESTAMP = $(VENV)/.requirements.timestamp
+DEV_REQUIREMENTS_TIMESTAMP = $(VENV)/.dev-requirements.timestamp
+
+# general targets timestamps
+TIMESTAMPS = .timestamps
+SYSTEM_PYTHON_TIMESTAMP = $(TIMESTAMPS)/.python-system.timestamp
+PYTHON_LOCAL_BUILD_TIMESTAMP = $(TIMESTAMPS)/.python-build.timestamp
+DOCKER_BUILD_TIMESTAMP = $(TIMESTAMPS)/.dockerbuild.timestamp
+
+# Find all python files that are not inside a hidden directory (directory starting with .)
+PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
+
 PYTHON_VERSION := 3.7.4
-SYSTEM_PYTHON_CMD := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
+SYSTEM_PYTHON := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
 
 # default configuration
 HTTP_PORT ?= 5000
 
 # Commands
-PYTHON_CMD := $(INSTALL_DIR)/bin/python3
-PIP_CMD := $(INSTALL_DIR)/bin/pip3
-FLASK_CMD := $(INSTALL_DIR)/bin/flask
-YAPF_CMD := $(INSTALL_DIR)/bin/yapf
-NOSE_CMD := $(INSTALL_DIR)/bin/nose2
-PYLINT_CMD := $(INSTALL_DIR)/bin/pylint
+PYTHON := $(VENV)/bin/python3
+PIP := $(VENV)/bin/pip3
+FLASK := $(VENV)/bin/flask
+YAPF := $(VENV)/bin/yapf
+NOSE := $(VENV)/bin/nose2
+PYLINT := $(VENV)/bin/pylint
+
+
 all: help
-
-# This bit check define the build/python "target": if the system has an acceptable version of python, there will be no need to install python locally.
-
-ifneq ($(SYSTEM_PYTHON_CMD),)
-build/python:
-	@echo "Using system" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
-	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
-	mkdir -p build
-	touch build/python
-else
-build/python: $(PYTHON_LOCAL_DIR)/bin/python3.7
-	@echo "Using local" $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1)
-	@echo $(shell $(SYSTEM_PYTHON_CMD) -c "print('OK')")
-
-SYSTEM_PYTHON_CMD := $(PYTHON_LOCAL_DIR)/bin/python3.7
-endif
-
 
 
 .PHONY: help
@@ -48,10 +51,13 @@ help:
 	@echo "Usage: make <target>"
 	@echo
 	@echo "Possible targets:"
-	@echo -e " \033[1mBUILD TARGETS\033[0m "
+	@echo -e " \033[1mSetup TARGETS\033[0m "
 	@echo "- setup              Create the python virtual environment"
-	@echo -e " \033[1mLINTING TOOLS TARGETS\033[0m "
-	@echo "- lint               Lint and format the python source code"
+	@echo "- dev                Create the python virtual environment with developper tools"
+	@echo -e " \033[1mFORMATING, LINTING AND TESTING TOOLS TARGETS\033[0m "
+	@echo "- format             Format the python source code"
+	@echo "- lint               Lint the python source code"
+	@echo "- format-lint        Format and lint the python source code"
 	@echo "- test               Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
 	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 5000)"
@@ -63,72 +69,136 @@ help:
 	@echo "- clean              Clean genereated files"
 	@echo "- clean_venv         Clean python venv"
 
-# Build targets. Calling setup is all that is needed for the local files to be installed as needed. Bundesnetz may cause problem.
 
-python: build/python
-	@echo $(shell $(SYSTEM_PYTHON_CMD) --version 2>&1) "installed"
+# Build targets. Calling setup is all that is needed for the local files to be installed as needed.
+
+.PHONY: dev
+dev: $(DEV_REQUIREMENTS_TIMESTAMP)
+
 
 .PHONY: setup
-setup: python .venv/build.timestamp
+setup: $(REQUIREMENTS_TIMESTAMP)
 
-
-$(PYTHON_LOCAL_DIR)/bin/python3.7:
-	@echo "Building a local python..."
-	mkdir -p $(PYTHON_LOCAL_DIR);
-	curl -z $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz;
-	cd $(PYTHON_LOCAL_DIR) && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(PYTHON_LOCAL_DIR)/ && make altinstall
-
-.venv/build.timestamp: build/python
-	$(SYSTEM_PYTHON_CMD) -m venv $(INSTALL_DIR) && $(PIP_CMD) install --upgrade pip setuptools
-	${PIP_CMD} install -r dev_requirements.txt
-	$(PIP_CMD) install -r requirements.txt
-	touch .venv/build.timestamp
 
 # linting target, calls upon yapf to make sure your code is easier to read and respects some conventions.
 
+.PHONY: format
+format: $(DEV_REQUIREMENTS_TIMESTAMP)
+	$(YAPF) -p -i --style .style.yapf $(PYTHON_FILES)
+
+
 .PHONY: lint
-lint: .venv/build.timestamp
-	$(YAPF_CMD) -p -i --style .style.yapf $(PYTHON_FILES)
-	$(PYLINT_CMD) $(PYTHON_FILES)
+lint: $(DEV_REQUIREMENTS_TIMESTAMP)
+	$(PYLINT) $(PYTHON_FILES)
+
+
+.PHONY: format-lint
+format-lint: format lint
+
+
+# Test target
 
 .PHONY: test
-test: .venv/build.timestamp
+test: $(DEV_REQUIREMENTS_TIMESTAMP)
 	mkdir -p $(TEST_REPORT_DIR)
-	$(NOSE_CMD) -c tests/unittest.cfg --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path $(TEST_REPORT_DIR)/$(TEST_REPORT_FILE) -s tests/
+	$(NOSE) -c tests/unittest.cfg --plugin nose2.plugins.junitxml --junit-xml --junit-xml-path $(TEST_REPORT_DIR)/$(TEST_REPORT_FILE) -s tests/
+
 
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.
+
 .PHONY: serve
-serve: .venv/build.timestamp
-	FLASK_APP=service_color FLASK_DEBUG=1 $(FLASK_CMD) run --host=0.0.0.0 --port=$(HTTP_PORT)
+serve: $(REQUIREMENTS_TIMESTAMP)
+	FLASK_APP=$(subst -,_,$(SERVICE_NAME)) FLASK_DEBUG=1 $(FLASK) run --host=0.0.0.0 --port=$(HTTP_PORT)
+
 
 .PHONY: gunicornserve
-gunicornserve: .venv/build.timestamp
-	${PYTHON_CMD} wsgi.py
+gunicornserve: $(REQUIREMENTS_TIMESTAMP)
+	$(PYTHON) wsgi.py
+
 
 # Docker related functions.
 
 .PHONY: dockerbuild
-dockerbuild:
-	docker build -t swisstopo/service-color:local .
+dockerbuild: $(DOCKER_BUILD_TIMESTAMP)
 
-export-http-port:
-	@export HTTP_PORT=$(HTTP_PORT)
 
 .PHONY: dockerrun
-dockerrun: export-http-port
-	docker-compose up -d;
-	sleep 10
+dockerrun: $(DOCKER_BUILD_TIMESTAMP)
+	HTTP_PORT=$(HTTP_PORT) docker-compose up -d
+	sleep 5
+
 
 .PHONY: shutdown
-shutdown: export-http-port
-	docker-compose down
+shutdown:
+	HTTP_PORT=$(HTTP_PORT) docker-compose down
 
-# Cleaning functions. clean_venv will only remove the virtual environment, while clean will also remove the local python installation.
-
-.PHONY: clean
-clean: clean_venv
-	rm -rf build;
 
 .PHONY: clean_venv
 clean_venv:
-	rm -rf ${INSTALL_DIR};
+	rm -rf $(VENV)
+
+
+.PHONY: clean
+clean: clean_venv
+	@# clean python cache files
+	find . -name __pycache__ -type d -print0 | xargs -I {} -0 rm -rf "{}"
+	rm -rf $(PYTHON_LOCAL_DIR)
+	rm -rf $(TEST_REPORT_DIR)
+	rm -rf $(TIMESTAMPS)
+
+
+# Actual builds targets with dependencies
+
+$(TIMESTAMPS):
+	mkdir -p $(TIMESTAMPS)
+
+
+$(VENV_TIMESTAMP): $(SYSTEM_PYTHON_TIMESTAMP)
+	test -d $(VENV) || $(SYSTEM_PYTHON) -m venv $(VENV) && $(PIP) install --upgrade pip setuptools
+	@touch $(VENV_TIMESTAMP)
+
+
+$(REQUIREMENTS_TIMESTAMP): $(VENV_TIMESTAMP) $(REQUIREMENTS)
+	$(PIP) install -U pip wheel; \
+	$(PIP) install -r $(REQUIREMENTS);
+	@touch $(REQUIREMENTS_TIMESTAMP)
+
+
+$(DEV_REQUIREMENTS_TIMESTAMP): $(REQUIREMENTS_TIMESTAMP) $(DEV_REQUIREMENTS)
+	$(PIP) install -r $(DEV_REQUIREMENTS)
+	@touch $(DEV_REQUIREMENTS_TIMESTAMP)
+
+
+$(DOCKER_BUILD_TIMESTAMP): $(TIMESTAMPS) $(PYTHON_FILES) $(CURRENT_DIR)/Dockerfile
+	docker build -t swisstopo/$(SERVICE_NAME):local .
+	touch $(DOCKER_BUILD_TIMESTAMP)
+
+
+# Python local build target
+
+ifneq ($(SYSTEM_PYTHON),)
+
+# A system python matching version has been found use it
+$(SYSTEM_PYTHON_TIMESTAMP): $(TIMESTAMPS)
+	@echo "Using system" $(shell $(SYSTEM_PYTHON) --version 2>&1)
+	touch $(SYSTEM_PYTHON_TIMESTAMP)
+
+
+else
+
+# No python version found, build it localy
+$(SYSTEM_PYTHON_TIMESTAMP): $(TIMESTAMPS) $(PYTHON_LOCAL_BUILD_TIMESTAMP)
+	@echo "Using local" $(shell $(SYSTEM_PYTHON) --version 2>&1)
+	touch $(SYSTEM_PYTHON_TIMESTAMP)
+
+
+$(PYTHON_LOCAL_BUILD_TIMESTAMP): $(TIMESTAMPS)
+	@echo "Building a local python..."
+	mkdir -p $(PYTHON_LOCAL_DIR);
+	curl -z $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz https://www.python.org/ftp/python/$(PYTHON_VERSION)/Python-$(PYTHON_VERSION).tar.xz -o $(PYTHON_LOCAL_DIR)/Python-$(PYTHON_VERSION).tar.xz;
+	cd $(PYTHON_LOCAL_DIR) && tar -xf Python-$(PYTHON_VERSION).tar.xz && Python-$(PYTHON_VERSION)/configure --prefix=$(PYTHON_LOCAL_DIR)/ && make altinstall
+	touch $(PYTHON_LOCAL_BUILD_TIMESTAMP)
+
+SYSTEM_PYTHON := $(PYTHON_LOCAL_DIR)/python
+
+endif

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,26 +23,39 @@ phases:
   pre_build:
     commands:
       - echo "export of the image tag for build and push purposes"
+      # Reading git branch (the utility in the deploy script is unable to read it automatically on CodeBuild)
+      # see https://stackoverflow.com/questions/47657423/get-github-git-branch-for-aws-codebuild
+      - export GITHUB_BRANCH="$(git symbolic-ref HEAD --short 2>/dev/null)"
+      - |
+        if [ "${GITHUB_BRANCH}" = "" ] ; then
+          GITHUB_BRANCH="$(git branch -a --contains HEAD | sed -n 2p | awk '{ printf $1 }')";
+          export GITHUB_BRANCH=${GITHUB_BRANCH#remotes/origin/};
+        fi
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - GITHUB_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/*}
-      # Manual build don't have the CODEBUILD_WEBHOOK_HEAD_REF variable set, therefore use the source version set during the manual build
-      - GITHUB_BRANCH=${GITHUB_BRANCH:-${CODEBUILD_SOURCE_VERSION}}
       - export IMAGE_TAG="${GITHUB_BRANCH}.${COMMIT_HASH}"
+      - echo "GITHUB_BRANCH=${GITHUB_BRANCH} COMMIT_HASH=${COMMIT_HASH} IMAGE_TAG=${IMAGE_TAG}"
       - echo "creating a clean environment"
       - make clean setup
   build:
     commands:
-      - echo "we need to tag the image correctly, and this should depend on the branch it's from, and / or the branch"
-      - echo "it's merged into."
-      - docker build -t ${IMAGE_BASE_NAME}:${IMAGE_TAG} .
+      - echo Build started on $(date)
+      - export DOCKER_IMG_TAG_BASE=${IMAGE_BASE_NAME}:${GITHUB_BRANCH}
+      - export DOCKER_IMG_TAG_HASH=${DOCKER_IMG_TAG_BASE}.${COMMIT_HASH}
+      - export DOCKER_IMG_TAG_LATEST=${DOCKER_IMG_TAG_BASE}.latest
+      - echo "Building docker image with tags ${DOCKER_IMG_TAG_HASH} and ${DOCKER_IMG_TAG_LATEST}"
+      - docker build -t ${DOCKER_IMG_TAG_HASH} -t ${DOCKER_IMG_TAG_LATEST} .
+
   post_build:
     commands:
-      - .venv/bin/pylint $(find ./* -type f -name "*.py" -print)
+      - make lint
       - mkdir -p ${TEST_REPORT_DIR}
-      - export TEST_REPORT_DIR=${TEST_REPORT_DIR}
-      - export TEST_REPORT_FILE=${TEST_REPORT_FILE}
-      - make test
-      - docker push ${IMAGE_BASE_NAME}:${IMAGE_TAG}
+      - TEST_REPORT_DIR=${TEST_REPORT_DIR} TEST_REPORT_FILE=${TEST_REPORT_FILE} make test
+      # Only push image to dockerhub for merge to develop and master
+      - |
+        if [ "${GITHUB_BRANCH}" = "master" -o "${GITHUB_BRANCH}" = "develop" ]; then
+          docker push ${DOCKER_IMG_TAG_HASH}
+          docker push ${DOCKER_IMG_TAG_LATEST}
+        fi
 
 reports:
   nose2_reports:


### PR DESCRIPTION
Now only images from master or develop branch are pushed to dockerhub
registry. The image that is push has always two tag; one
<branch>.<commit-hash> and one <branch>.latest.

Also ported the latest improvement makefile from service-qrcode which
fixes many dependencies issues.

Aslo fixed a small pylint issue due to logging and added the .isort.cfg
to be able to properly use isort.

See also https://github.com/geoadmin/service-qrcode/pull/14